### PR TITLE
add kaitai struct describing session file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Extract the GPS tracks of Soloshot 3 base and tags of a session file as GPX file
 [Try it out](https://maiermic.github.io/soloshot-session-to-gpx-converter/index.html).
 
 ## Session File Format
+_The following information is also available [here](session.ksy) as a [Kaitai Struct](https://kaitai.io/) file._
+
 The session file is a binary file. The first 4 bytes represent the ASCII encoded string `SOLO`. They are followed by 12 bytes of as yet unknown information (probably contains file version number). They are followed by packages that start with a byte `0xAA` (package separator), followed by the package type (1 byte), package data length (1 byte), package header (10 bytes) and the package data.
 
 

--- a/session.ksy
+++ b/session.ksy
@@ -18,7 +18,9 @@ types:
   pkg_hdr:
     seq:
       - id: unk0
-        size: 10
+        size: 2
+      - id: timestamp_ms
+        type: u8
   package:
     seq:
       - id: separator

--- a/session.ksy
+++ b/session.ksy
@@ -39,7 +39,7 @@ types:
             0xA5: vid_qual
             0x1D: ser_num_etc
             0x08: locations
-            0xA3: un_etc
+            0xA3: tag_info
             _: pkg_unk
   pkg_unk:
     seq:
@@ -83,7 +83,14 @@ types:
         type: s4
       - id: elev
         type: s4
-  un_etc:
+    instances:
+      lat_deg:
+        value: lat / 1000000.0
+      lon_deg:
+        value: lon / 1000000.0
+      elev_m:
+        value: elev / 100
+  tag_info:
     seq:
       - id: unk1
         size: 3

--- a/session.ksy
+++ b/session.ksy
@@ -1,7 +1,7 @@
 meta:
   id: session
   file-extension: SESSION
-  endian: le
+  endian: be
 seq:
   - id: header
     type: file_hdr
@@ -67,8 +67,6 @@ types:
         encoding: ASCII
   locations:
     seq:
-      - id: unk1
-        size: 9
       - id: tagnum
         type: u1
       - id: base_gps
@@ -80,11 +78,11 @@ types:
   latlon:
     seq:
       - id: lat
-        type: u4
+        type: s4
       - id: lon
-        type: u4
+        type: s4
       - id: elev
-        type: u4
+        type: s4
   un_etc:
     seq:
       - id: unk1

--- a/session.ksy
+++ b/session.ksy
@@ -1,0 +1,106 @@
+meta:
+  id: session
+  file-extension: SESSION
+  endian: le
+seq:
+  - id: header
+    type: file_hdr
+  - id: package
+    type: package
+    repeat: eos
+types:
+  file_hdr:
+    seq:
+      - id: magic
+        contents: 'SOLO'
+      - id: extra
+        size: 12
+  pkg_hdr:
+    seq:
+      - id: unk0
+        size: 10
+  package:
+    seq:
+      - id: separator
+        type: u1
+      - id: pkg_type
+        type: u1
+      - id: len
+        type: u1
+      - id: pkg_hdr
+        type: pkg_hdr
+      - id: body
+        size: len
+        type:
+          switch-on: pkg_type
+          cases:
+            0xA0: mystery_a0
+            0xA6: mystery_a6
+            0xA5: vid_qual
+            0x1D: ser_num_etc
+            0x08: locations
+            0xA3: un_etc
+            _: pkg_unk
+  pkg_unk:
+    seq:
+      - id: unk
+        size-eos: true
+  mystery_a0:
+    seq:
+      - id: unk
+        size-eos: true
+  mystery_a6:
+    seq:
+      - id: unk
+        size-eos: true
+  vid_qual:
+    seq:
+      - id: res_fps
+        type: str
+        size: 12
+        encoding: ASCII
+  ser_num_etc:
+    seq:
+      - id: sernum_tstamp_tagnum
+        type: str
+        terminator: 0
+        encoding: ASCII
+  locations:
+    seq:
+      - id: unk1
+        size: 9
+      - id: tagnum
+        type: u1
+      - id: base_gps
+        type: latlon
+      - id: tag_gps
+        type: latlon
+      - id: unk2
+        size-eos: true
+  latlon:
+    seq:
+      - id: lat
+        type: u4
+      - id: lon
+        type: u4
+      - id: elev
+        type: u4
+  un_etc:
+    seq:
+      - id: unk1
+        size: 3
+      - id: username
+        type: str
+        encoding: ASCII
+        terminator: 0
+        size: 41
+      - id: firmware_vers
+        type: str
+        encoding: ASCII
+        terminator: 0
+        size: 8
+      - id: unk_vers
+        type: str
+        encoding: ASCII
+        terminator: 0
+        size: 8

--- a/session.ksy
+++ b/session.ksy
@@ -92,8 +92,12 @@ types:
         value: elev / 100
   tag_info:
     seq:
-      - id: unk1
-        size: 3
+      - id: unk
+        size: 1
+      - id: tag_connection_id
+        type: u1
+      - id: tag_registration_id
+        type: u1
       - id: username
         type: str
         encoding: ASCII

--- a/session.ksy
+++ b/session.ksy
@@ -13,8 +13,10 @@ types:
     seq:
       - id: magic
         contents: 'SOLO'
-      - id: extra
-        size: 12
+      - id: unk
+        size: 4
+      - id: timestamp_ms
+        type: u8
   pkg_hdr:
     seq:
       - id: unk0


### PR DESCRIPTION
I tried using https://ide.kaitai.io/ to dig in to some of my session files, and I ended up writing a .ksy file for parsing the session files. .ksy files can be compiled to parsers in many programming languages. I'm putting it here in case you'd like to use it in this repo. I used README.md as my starting point for writing the .ksy.

I found one discrepancy between my .SESSION files and README.md when writing the .ksy: my 0xA3 packets starts with only 3 bytes unknown before the tag number, as opposed to the 12 bytes as listed in README.md

I'm hoping to figure out some more of the unknown stuff and if I do I would PR again to update this file.

You might consider replacing the js parser here with a Kaitai-generated JS parser, but the Kaitai-generated parsers are much more verbose so maybe not desired; I like how simple .html file in this repo is.